### PR TITLE
Add b64 header handling

### DIFF
--- a/lib/sign-stream.js
+++ b/lib/sign-stream.js
@@ -15,10 +15,13 @@ function base64url(string, encoding) {
     .replace(/\//g, '_');
 }
 
+// Normally, we concatenate the base64url encoded header and payload with a period ('.') in between.
+// However, if the header.b64 property is set to false, we do not base64url encode the payload.
+// See: https://directory.openbanking.org.uk/obieservicedesk/s/article/Can-you-explain-what-are-the-supported-values-of-b64-claim-for-different-versions-of-specifications
 function jwsSecuredInput(header, payload, encoding) {
   encoding = encoding || 'utf8';
   var encodedHeader = base64url(toString(header), 'binary');
-  var encodedPayload = base64url(toString(payload), encoding);
+  var encodedPayload = header.b64 !== false ? base64url(toString(payload), encoding) : toString(payload);
   return util.format('%s.%s', encodedHeader, encodedPayload);
 }
 


### PR DESCRIPTION
For x-jws-signature support, we need to handle when the payload is _not_ base64 encoded as part of the signature generation. This change does that, by checking for the `"b64": false` header being set. All other values are treated as before, and the payload is base64 URL encoded